### PR TITLE
chore: pull request template for team addition

### DIFF
--- a/workflows/pull_request_template.md
+++ b/workflows/pull_request_template.md
@@ -1,0 +1,11 @@
+
+## Changes proposed in this Pull Request
+
+
+## Pull Request Checklist for new entries on team website
+
+- [ ] Did you include your first and last name (without titles)?
+- [ ] If applicable, did you include your "Dr." / PhD title?
+- [ ] Did you upload your profile picture in the required format ([he](https://img.wetransfer.net/v1/eu/collections/3300407d98c8973110164c1918a89d5220241216135001/assets/hl-53289149701/preview_url?width=512&height=512&cb=transfer-pro&Expires=1734360722&Signature=Au3u-Po3g23NDTFMjHc68gsKumBPU1zuz9JDg~lhZ~~c-sKsOAPd5c1JFp5VhEqDJZZGdpGVCYhjrwg5rC~KXWwt2SxR0mNHvhNGWRubXrK31v1WsVc7Gm1Q387-Cm-zaSgpB5KVE-wDgq-5dBhuL7DwrCMqONfDI~4pGQslj6PApGTo77VUbaEKbj7denp~7XcWtEPqtxnfdXSZ7zbcpfRbU4fdOyQ-S10IpX15LXPRti34dqmgDy6g3OAQL5vcNFvPTd-uITHC~NrmrLcpksarmkw8Vo1Zt7G8yQeumPw~glDPTwpqQIc6vlaiggfce54RBtHQ0WdpCn1SdS~XaA__&Key-Pair-Id=K4ZSMBD51J822)/[she](https://img.wetransfer.net/v1/eu/collections/3300407d98c8973110164c1918a89d5220241216135001/assets/hl-53289149702/preview_url?width=512&height=512&cb=transfer-pro&Expires=1734360873&Signature=Sj0z0BYeWdr9Qo3lUoint3PvxdowUZrF-4NzfO1US2f7Q6w0fqLCGV8qac3US7TUbdsbhTQPIzy2motVqj~k-7awrgSZM0Y2Zer5JelQpemR6SbHyWQwQy3imMVUJs2EVNwbbJoYXfMIEf734fVZRwHSw7kqLKXyCkw1h76YPMJXyeGXNYZpkysejHkULvklo3IGy47EqaHt6Hz22SEq5ruO0Nk7jHCdLrppHXqE3hjeeq92Jtje8RDWlxwZb5Ay6eM2PWhJ7Zkf~XlAKjIUIf6QBGCc1hLtY64wTflOg8JkCI3Sxod8BXcIBf0T2WTy6X-izj1IOlb0zvCr2SN3aw__&Key-Pair-Id=K4ZSMBD51J822))?
+- [ ] Did you include your current role and department (if applicable)?
+- [ ] Did you review your changes to ensure they match the website’s tone and style?


### PR DESCRIPTION
From now on, we'll try directly uploading a standardized profile picture and website appearance, so that new team members need to directly follow the "template"... we'll still need to update the pictures for the existing team members. This shall reduce overhead replacing them in the long term